### PR TITLE
Issue#4 display request categories

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { checkHealth, Category } from "./api.js";
+import { checkSystem, Category } from "./api.js";
 
 // UI states you must handle for Issue 4: idle, loading, success, error.
 type UiState = "idle" | "loading" | "success" | "error";
@@ -8,17 +8,15 @@ export default function App() {
   const [state, setState] = useState<UiState>("idle");
   const [categories, setCategories] = useState<Category[]>([]);
   const [error, setError] = useState("");
-  void categories;
 
   async function handleCheck() {
-    // TODO(Issue 4): set loading, call checkSystem(), then either
-    //   - success: store categories and show Online + the list, or
-    //   - error: show Offline + a useful message.
     setState("loading");
     setError("");
+    setCategories([]);
 
     try {
-      await checkHealth();
+      const result = await checkSystem();
+      setCategories(result.categories);
       setState("success");
     } catch {
       setState("error");
@@ -36,15 +34,21 @@ export default function App() {
         {state === "loading" ? "Loading…" : "Check System"}
       </button>
 
-      {state === "success" && <p className="mt-3 text-success">System Status: Online</p>}
+      {state === "success" && (
+        <div className="mt-3 text-success">
+          <p className="mb-2">System Status: Online</p>
+          <h2 className="h5">Supported Request Categories</h2>
+          <ul className="mb-0">
+            {categories.map((category) => <li key={category.id}>{category.name}</li>)}
+          </ul>
+        </div>
+      )}
       {state === "error" && (
         <div className="mt-3 text-danger">
           <p className="mb-1">System Status: Offline</p>
           <p className="mb-0">{error}</p>
         </div>
       )}
-
-      {/* TODO(Issue 4): render loading / success (Online + categories) / error (Offline) states. */}
     </div>
   );
 }

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -27,6 +27,10 @@ export async function checkHealth(): Promise<HealthStatus> {
 //        return { online: true, categories }.
 // Throwing on failure lets the UI show a single Offline/error state.
 export async function checkSystem(): Promise<SystemStatus> {
-  // TODO(Issue 2 & 4): implement the two fetch calls described above.
-  throw new Error("checkSystem not implemented yet");
+  await checkHealth();
+
+  const response = await fetch(`${API_URL}/api/categories`);
+  if (!response.ok) throw new Error("Unable to load categories from TokTickIT API");
+
+  return { online: true, categories: await response.json() };
 }

--- a/client/tests/lab-01/App.test.tsx
+++ b/client/tests/lab-01/App.test.tsx
@@ -13,10 +13,10 @@ describe("App", () => {
     expect(screen.getByText(/TokTickIT/i)).toBeInTheDocument();
   });
 
-  it("shows Online after a successful health response", async () => {
-    const checkHealth = vi.spyOn(api, "checkHealth").mockResolvedValue({
-      status: "ok",
-      service: "TokTickIT API",
+  it("shows Online after a successful system response", async () => {
+    const checkSystem = vi.spyOn(api, "checkSystem").mockResolvedValue({
+      online: true,
+      categories: [],
     });
     const user = userEvent.setup();
 
@@ -24,11 +24,11 @@ describe("App", () => {
     await user.click(screen.getByRole("button", { name: "Check System" }));
 
     expect(await screen.findByText("System Status: Online")).toBeInTheDocument();
-    expect(checkHealth).toHaveBeenCalledOnce();
+    expect(checkSystem).toHaveBeenCalledOnce();
   });
 
-  it("shows Offline and a useful message when health fails", async () => {
-    vi.spyOn(api, "checkHealth").mockRejectedValue(new Error("request failed"));
+  it("shows Offline and a useful message when the system check fails", async () => {
+    vi.spyOn(api, "checkSystem").mockRejectedValue(new Error("request failed"));
     const user = userEvent.setup();
 
     render(<App />);
@@ -38,9 +38,51 @@ describe("App", () => {
     expect(screen.getByText("Unable to connect to TokTickIT API")).toBeInTheDocument();
   });
 
-  // Issue 4 — write these yourself. Hint: mock the api module with
-  // vi.spyOn(api, "checkSystem").mockResolvedValue(...) / .mockRejectedValue(...)
-  // then click the button and assert the Online list / Offline message.
-  it.todo("shows Online and the seeded categories on success");
-  it.todo("shows an Offline error message when the API is unavailable");
+  it("shows loading, Online, and categories from the API result", async () => {
+    let resolveCheck!: (result: api.SystemStatus) => void;
+    const pendingCheck = new Promise<api.SystemStatus>((resolve) => {
+      resolveCheck = resolve;
+    });
+    vi.spyOn(api, "checkSystem").mockReturnValue(pendingCheck);
+    const user = userEvent.setup();
+
+    render(<App />);
+    await user.click(screen.getByRole("button", { name: "Check System" }));
+
+    expect(screen.getByRole("button", { name: "Loading…" })).toBeDisabled();
+
+    resolveCheck({
+      online: true,
+      categories: [
+        { id: 1, name: "Account and Access" },
+        { id: 2, name: "Hardware" },
+        { id: 3, name: "Software" },
+        { id: 4, name: "Network" },
+      ],
+    });
+
+    expect(await screen.findByText("System Status: Online")).toBeInTheDocument();
+    expect(screen.getByText("Supported Request Categories")).toBeInTheDocument();
+    expect(screen.getByText("Account and Access")).toBeInTheDocument();
+    expect(screen.getByText("Hardware")).toBeInTheDocument();
+    expect(screen.getByText("Software")).toBeInTheDocument();
+    expect(screen.getByText("Network")).toBeInTheDocument();
+  });
+
+  it("clears stale categories and shows Offline when the API is unavailable", async () => {
+    vi.spyOn(api, "checkSystem")
+      .mockResolvedValueOnce({ online: true, categories: [{ id: 1, name: "Hardware" }] })
+      .mockRejectedValueOnce(new Error("request failed"));
+    const user = userEvent.setup();
+
+    render(<App />);
+    await user.click(screen.getByRole("button", { name: "Check System" }));
+    expect(await screen.findByText("Hardware")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Check System" }));
+
+    expect(await screen.findByText("System Status: Offline")).toBeInTheDocument();
+    expect(screen.getByText("Unable to connect to TokTickIT API")).toBeInTheDocument();
+    expect(screen.queryByText("Hardware")).not.toBeInTheDocument();
+  });
 });

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -27,7 +27,17 @@ app.get("/api/health", (_req: Request, res: Response) => {
 //   -> read categories from PostgreSQL via getPrisma().category.findMany(...)
 //   -> return each { id, name } in a predictable (id) order
 //   -> on failure, respond 500 with a safe message (no internal details)
-// TODO(Issue 4): implement the route here.
 // ---------------------------------------------------------------------------
+app.get("/api/categories", async (_req: Request, res: Response) => {
+  try {
+    const categories = await getPrisma().category.findMany({
+      orderBy: { id: "asc" },
+      select: { id: true, name: true },
+    });
+    res.status(200).json(categories);
+  } catch {
+    res.status(500).json({ error: "Unable to load categories" });
+  }
+});
 
 export default app;

--- a/server/tests/lab-01/categories.test.ts
+++ b/server/tests/lab-01/categories.test.ts
@@ -1,15 +1,25 @@
 import { describe, it, expect } from "vitest";
 import request from "supertest";
 import { app } from "../../src/app.js";
-void request; void app;
 
-// Issue 4 — write this test yourself, using health.test.ts as the pattern.
-// Requires the DB to be migrated and seeded first.
-// It should assert: GET /api/categories returns 200 and the four seeded
-// category names in id order.
-describe.todo("GET /api/categories", () => {
-  it.todo("returns the four seeded categories in id order", async () => {
-    // TODO(Issue 4): implement this assertion.
-    expect(true).toBe(true);
+describe("GET /api/categories", () => {
+  it("returns the four seeded categories in id order", async () => {
+    const res = await request(app).get("/api/categories");
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body).toHaveLength(4);
+    expect(res.body.map((category: { name: string }) => category.name)).toEqual([
+      "Account and Access",
+      "Hardware",
+      "Software",
+      "Network",
+    ]);
+    expect(res.body.map((category: { id: number }) => category.id)).toEqual(
+      [...res.body.map((category: { id: number }) => category.id)].sort((a, b) => a - b),
+    );
+    expect(res.body.every((category: Record<string, unknown>) => {
+      return Object.keys(category).sort().join(",") === "id,name";
+    })).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Implement the Prisma-backed category API and display the supported request categories in the React UI.

## Verification

- [x] `GET /api/categories` returns HTTP 200.
- [x] Categories are loaded from PostgreSQL through Prisma.
- [x] Response items contain only `id` and `name`.
- [x] Categories are ordered by ascending `id`.
- [x] Supertest verifies the endpoint.
- [x] React renders API-returned categories.
- [x] Loading state is displayed.
- [x] API/database failure displays Offline and a useful error message.
- [x] Vitest verifies category-list UI behavior.
- [x] No category data is hard-coded.
- [x] No schema, migration, seed, package, or credential changes were made.

## Test results

- Server tests: 2 passed
- Client tests: 5 passed
- Client production build: passed
- Backend TypeScript check: passed
- Prisma migration status: database up to date

Closes #4