### PR TITLE
docs(lab2): promote peer-review evidence to main

### DIFF
--- a/docs/lab-02/reviewer.md
+++ b/docs/lab-02/reviewer.md
@@ -11,14 +11,38 @@ This file records only peer-review evidence that actually occurred. Approval is 
 - Issue: [#15 — Lab 2: Sprint Engineering Contract and Test Plan](https://github.com/Tanaboonnnnn/toktickit/issues/15)
 - Pull request: [#16](https://github.com/Tanaboonnnnn/toktickit/pull/16) → `lab2-staging`
 
-## Reviewer
+## Reviewers
 
 - Name: พลัฏฐ์ อมาตย์ชยาภา
 - Student ID: `67070507212`
 - GitHub username: `@L0u1sss`
-- Current review status: **Approved and merged** (PR #16)
+- Lab 2 review coverage verified on GitHub: PR #16, PR #21, PR #25, and PR #27.
+
+- Name: ฌาธนัชย์ อุทัยพิบูลย์
+- Student ID: `67070507210`
+- GitHub username: `@Chxtamos`
+- Lab 2 review coverage verified on GitHub: PR #17, PR #19, PR #21, PR #23, PR #27, PR #29, PR #31, PR #32, PR #34, and PR #33.
 
 ## Reviews received
+
+The table below lists the Lab 2 PR reviews verified from the GitHub review history for this repository. Detailed notes are kept below for the review cycles that produced important changes to the work.
+
+| PR | Scope | Reviewer(s) | Verified review outcome |
+|---|---|---|---|
+| [#16](https://github.com/Tanaboonnnnn/toktickit/pull/16) | Engineering Contract / Test Plan | `@L0u1sss` | Changes requested, then approved and merged |
+| [#17](https://github.com/Tanaboonnnnn/toktickit/pull/17) | Development Requester | `@Chxtamos` | Changes requested, then approved |
+| [#19](https://github.com/Tanaboonnnnn/toktickit/pull/19) | Ticket Creation API | `@Chxtamos` | Changes requested, then approved |
+| [#21](https://github.com/Tanaboonnnnn/toktickit/pull/21) | Create Ticket UI | `@Chxtamos`, `@L0u1sss` | Changes requested were recorded; no final approval was verified before merge |
+| [#23](https://github.com/Tanaboonnnnn/toktickit/pull/23) | My Tickets | `@Chxtamos` | Approved |
+| [#25](https://github.com/Tanaboonnnnn/toktickit/pull/25) | Ticket Detail | `@L0u1sss` | Approved |
+| [#27](https://github.com/Tanaboonnnnn/toktickit/pull/27) | Attachment lifecycle | `@L0u1sss`, `@Chxtamos` | Changes requested during review; final approval recorded by `@Chxtamos` |
+| [#29](https://github.com/Tanaboonnnnn/toktickit/pull/29) | E2E / Responsive quality | `@Chxtamos` | Changes requested, then approved |
+| [#31](https://github.com/Tanaboonnnnn/toktickit/pull/31) | Release readiness | `@Chxtamos` | Approved |
+| [#32](https://github.com/Tanaboonnnnn/toktickit/pull/32) | Final evidence sync | `@Chxtamos` | Approved |
+| [#34](https://github.com/Tanaboonnnnn/toktickit/pull/34) | Release hygiene | `@Chxtamos` | Approved |
+| [#33](https://github.com/Tanaboonnnnn/toktickit/pull/33) | Final Lab 2 release | `@Chxtamos` | Changes requested, then approved and merged to `main` |
+
+## Detailed review evidence
 
 ### Review 1 — 2026-08-24 11:20 UTC
 
@@ -104,16 +128,98 @@ This file records only peer-review evidence that actually occurred. Approval is 
 - Merge: PR #31 merged into `lab2-staging` at 2026-08-30 15:20 UTC as merge commit [`2acc5bb`](https://github.com/Tanaboonnnnn/toktickit/commit/2acc5bb1574780f740a29b89a3cc57e6f02b50ac).
 - Status: **Approved and merged**.
 
+## Final release PR #33 review evidence
+
+- Pull request: [PR #33](https://github.com/Tanaboonnnnn/toktickit/pull/33) from `lab2-staging` to `main`.
+- Reviewer: `@Chxtamos`.
+- Initial result: **Changes requested** because the release diff still contained trailing whitespace in `docs/lab-02/specification.md`, while the release evidence claimed `git diff --check` was clean.
+- Resolution: PR [#34](https://github.com/Tanaboonnnnn/toktickit/pull/34) removed the release-blocking whitespace without changing application, API, database, or test behavior.
+- Final result: **Approved** after the updated release head was checked again. [Final approval](https://github.com/Tanaboonnnnn/toktickit/pull/33#pullrequestreview-5066705949)
+- Merge: PR #33 merged into `main` as final Lab 2 release commit [`9f0c279`](https://github.com/Tanaboonnnnn/toktickit/commit/9f0c27997b3e99da2379f3373dea30e1dded7dd0).
+
 ### Issue #13 clarification
 
 Issue [#13](https://github.com/Tanaboonnnnn/toktickit/issues/13) was an early duplicate planning artifact. It is closed with GitHub state reason `duplicate`, and its clarification comment points to Issue #15 / PR #16 as the authoritative Engineering Contract workflow. No separate implementation or deliverable belongs to Issue #13.
 
-## Reviews given to a partner
+## Reviews given to peers
 
-| Partner name / GitHub username | Student ID if required | PR link | Review date | Review comments link | Partner response/resolution |
-|---|---|---|---|---|---|
-| `@L0u1sss` | `67070507212` | [L0u1sss/TokTickIT PR #24](https://github.com/L0u1sss/TokTickIT/pull/24) | 2026-08-29 | [Changes Requested](https://github.com/L0u1sss/TokTickIT/pull/24#pullrequestreview-5058596777); [final Approval](https://github.com/L0u1sss/TokTickIT/pull/24#pullrequestreview-5058937767) | Reviewed requester isolation, query-contract consistency, invalid URL-query handling, and reference-metadata failure states. The partner [responded with the fix summary](https://github.com/L0u1sss/TokTickIT/pull/24#issuecomment-5463665186), adding strict URL validation, an invalid-query state, metadata Loading/Error/Retry, safe error handling, tests, and synchronized docs. Re-review approved the fixes; PR #24 then merged into `lab2-staging`. |
+GitHub Pull Requests search with `reviewed-by:Tanaboonnnnn` shows Lab 2 review activity in three classmates' TokTickIT repositories. Lab 1-only results are intentionally excluded from this section.
+
+### `@L0u1sss` — 6 Lab 2 PRs reviewed
+
+| PR | Scope | Review evidence |
+|---|---|---|
+| [#20](https://github.com/L0u1sss/TokTickIT/pull/20) | Specification, UI Tokens, and Test Plan Documentation | Review present on GitHub; latest search state showed Approved |
+| [#21](https://github.com/L0u1sss/TokTickIT/pull/21) | PostgreSQL Schema Design, Prisma Migrations, and Seed Data | Review present on GitHub; latest search state showed Approved |
+| [#22](https://github.com/L0u1sss/TokTickIT/pull/22) | Requester selection context | Review present on GitHub; latest search state showed Approved |
+| [#23](https://github.com/L0u1sss/TokTickIT/pull/23) | Create Ticket API, UI, and idempotency | Review present on GitHub; latest search state showed Approved |
+| [#24](https://github.com/L0u1sss/TokTickIT/pull/24) | Requester-scoped My Tickets list | [Changes Requested](https://github.com/L0u1sss/TokTickIT/pull/24#pullrequestreview-5058596777), partner [fix response](https://github.com/L0u1sss/TokTickIT/pull/24#issuecomment-5463665186), then [final Approval](https://github.com/L0u1sss/TokTickIT/pull/24#pullrequestreview-5058937767) |
+| [#27](https://github.com/L0u1sss/TokTickIT/pull/27) | Final E2E verification and release preparation | Review present on GitHub; latest search state showed Approved |
+
+The PR #24 review covered requester isolation, query-contract consistency, invalid URL-query handling, and reference-metadata failure states. The response added strict URL validation, an invalid-query state, metadata Loading/Error/Retry, safe error handling, tests, and synchronized docs before the re-review was approved.
+
+#### Selected detailed review — PR #24
+
+- **What I checked:** requester ownership isolation, URL-query validation, consistency with the My Tickets API contract, and loading/error/retry behavior for reference metadata.
+- **What I found:** the URL-query handling was too permissive and the UI did not yet have a clear invalid-query state. Reference metadata also needed explicit Loading/Error/Retry states so a failed metadata request would not leave the screen ambiguous.
+- **What I requested:** strict query validation, a visible invalid-query state, safe error handling, and explicit metadata failure/retry behavior with tests and documentation kept in sync.
+- **Partner response:** `@L0u1sss` replied with the implemented fixes, including strict URL validation, the invalid-query state, metadata Loading/Error/Retry, safe errors, tests, and synchronized docs.
+- **Re-review result:** I checked the updated PR and approved it. Evidence: [Changes Requested](https://github.com/L0u1sss/TokTickIT/pull/24#pullrequestreview-5058596777) → [partner response](https://github.com/L0u1sss/TokTickIT/pull/24#issuecomment-5463665186) → [final Approval](https://github.com/L0u1sss/TokTickIT/pull/24#pullrequestreview-5058937767).
+
+### `@Peepipat-Suesoongnuen` — 13 Lab 2 PRs reviewed
+
+| PR | Scope | Latest review state shown by GitHub search |
+|---|---|---|
+| [#24](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/24) | My Tickets - owned paginated list, search/filter/sort/pagination | Changes requested |
+| [#25](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/25) | Ticket Detail + Attachment lifecycle | Approved |
+| [#26](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/26) | E2E tests + responsive Playwright screenshots | Approved |
+| [#28](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/28) | Add missing Create Ticket coverage | Approved |
+| [#29](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/29) | Complete Zen Green UI style and docs | Approved |
+| [#32](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/32) | Refine My Tickets search, sorting, and navigation | Approved |
+| [#33](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/33) | Add Back to My Tickets navigation | Approved |
+| [#35](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/35) | Refine My Tickets readability and filters | Approved |
+| [#36](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/36) | Complete release integration evidence | Approved |
+| [#37](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/37) | Lab 2 release | Changes requested, then approved on re-review |
+| [#39](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/39) | Keep tickets visible during sorting | Approved |
+| [#41](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/41) | Sync final evidence to staging | Approved |
+| [#42](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/42) | Promote final evidence to main | Approved |
+
+#### Selected detailed review — PR #37
+
+- **What I checked:** the exact `lab2-staging` release head, the release PR path to `main`, Issue #19 acceptance criteria, final evidence documents, and the hosted client/server/E2E CI state.
+- **What I found:** the release head itself was in good shape, but Issue #19 had already been closed as Completed even though its own acceptance criteria required it to stay open until the release PR was merged to `main`, the exact final-main CI was green, and the final evidence sync was complete.
+- **What I requested:** reopen Issue #19 and keep it open until the post-merge final-main gate was finished. I treated this as a process/evidence blocker, not a product-code blocker.
+- **Partner response:** the issue was reopened, `reviewer.md` was synchronized to record the release review, and the exact-head CI was rerun with client/server/E2E green. The follow-up was documentation/process-state only; no production or test behavior was changed for this fix.
+- **Re-review result:** after confirming the issue state and exact-head CI, I approved the release PR. I also noted that final-main verification and the final evidence sync still had to happen after merge before Issue #19 could be closed again.
+
+### `@Chxtamos` — 15 Lab 2 PRs reviewed
+
+| PR | Scope | Review evidence |
+|---|---|---|
+| [#13](https://github.com/Chxtamos/-TokTickIT-/pull/13) | Engineering contract and test plan | Review present on GitHub |
+| [#15](https://github.com/Chxtamos/-TokTickIT-/pull/15) | Lab 2 data model and seed | Review present on GitHub |
+| [#17](https://github.com/Chxtamos/-TokTickIT-/pull/17) | Requester context API | Review present on GitHub |
+| [#19](https://github.com/Chxtamos/-TokTickIT-/pull/19) | Ticket creation API | Review present on GitHub |
+| [#21](https://github.com/Chxtamos/-TokTickIT-/pull/21) | My Tickets API | Review present on GitHub |
+| [#25](https://github.com/Chxtamos/-TokTickIT-/pull/25) | Attachment Lifecycle API | Review present on GitHub |
+| [#27](https://github.com/Chxtamos/-TokTickIT-/pull/27) | Development Requester selection and application shell | Review present on GitHub |
+| [#29](https://github.com/Chxtamos/-TokTickIT-/pull/29) | Create Ticket UI | Review present on GitHub |
+| [#31](https://github.com/Chxtamos/-TokTickIT-/pull/31) | My Tickets screen | Review present on GitHub |
+| [#33](https://github.com/Chxtamos/-TokTickIT-/pull/33) | Requester Ticket Detail screen | Review present on GitHub |
+| [#35](https://github.com/Chxtamos/-TokTickIT-/pull/35) | Attachment lifecycle UI | Review present on GitHub |
+| [#37](https://github.com/Chxtamos/-TokTickIT-/pull/37) | Zen Green style and accessibility evidence | Review present on GitHub |
+| [#44](https://github.com/Chxtamos/-TokTickIT-/pull/44) | E2E requester and ticket creation flow | Changes requested, then approved on re-review |
+| [#45](https://github.com/Chxtamos/-TokTickIT-/pull/45) | E2E My Tickets ownership and Ticket Detail flow | Review present on GitHub; latest search state showed Approved |
+| [#46](https://github.com/Chxtamos/-TokTickIT-/pull/46) | E2E Attachment lifecycle flow | Review present on GitHub; latest search state showed Changes requested |
+
+#### Selected detailed review — PR #44
+
+- **What I checked:** the PR body and linked Issue, Lab 2 specification/test evidence, the requester-to-Ticket E2E flow, exact-head CI, seed behavior, and whether the evidence matched the scope actually implemented.
+- **What I found:** the E2E-01 flow itself was strong, including requester selection, ambiguous create-response handling, retry of the same logical request, mixed PDF/PNG attachment behavior, partial attachment failure with individual retry, and authoritative metadata checks. The blocker was traceability: the PR was being treated like the complete final-verification Issue even though `tests.md` still had E2E-02 through E2E-06 as Planned, and the workflow had only one seed run even though the final-verification criteria called for a seed-twice idempotency check.
+- **What I requested:** either complete the full final-verification evidence or narrow the PR back to the E2E-01 feature scope. I also asked for the seed-twice verification required by the final gate and for the evidence to stop overclaiming unimplemented E2E IDs.
+- **Partner response:** the PR scope was corrected to Feature 18 / Issue #38 / E2E-01 only, the separate final-verification Issue was left as a follow-up, the workflow ran `prisma:seed` twice, and `tests.md` marked only E2E-01 as PASS while E2E-02 through E2E-06 stayed Planned.
+- **Re-review result:** I rechecked the updated scope and exact-head CI. Client, server, and hosted E2E were green, the traceability mismatch was gone, and I approved the PR.
 
 ## Evidence integrity note
 
-This file records review evidence verified from the live public GitHub artifacts for PR #16, PR #29, PR #31, Issue #13, and partner PR #24, plus identity metadata already present in the approved repository evidence. It does not claim a hosted passing-check link for PR #29 because none was verified. Test/build/Prisma/browser results are local execution evidence in `tests.md`, not substitutes for peer approval.
+This file records review evidence verified from the live GitHub Pull Requests pages and PR timelines for the Lab 2 work above. The received-review index covers the Lab 2 PRs reviewed by `@L0u1sss` and `@Chxtamos`; the reviews-given section covers the Lab 2 PRs found for `@L0u1sss`, `@Peepipat-Suesoongnuen`, and `@Chxtamos` under `reviewed-by:Tanaboonnnnn`. Lab 1-only review results are excluded from the Lab 2 tables. The file does not claim a hosted passing-check link where none was verified. Test/build/Prisma/browser results in `tests.md` are local execution evidence, not substitutes for peer approval.

--- a/docs/lab-02/reviewer.md
+++ b/docs/lab-02/reviewer.md
@@ -4,22 +4,22 @@ This file records only peer-review evidence that actually occurred. Approval is 
 
 ## Author and review context
 
-- Author name: `เนเธ—เธเธเธธเธ เน€เธ•เธตเธขเธงเธชเธงเธฑเธชเธ”เธดเน`
+- Author name: `แทนบุญ เตียวสวัสดิ์`
 - Student ID: `67070507211`
 - GitHub username: `@Tanaboonnnnn`
 - Feature branch: `feature/5-lab2-engineering-contract`
-- Issue: [#15 โ€” Lab 2: Sprint Engineering Contract and Test Plan](https://github.com/Tanaboonnnnn/toktickit/issues/15)
-- Pull request: [#16](https://github.com/Tanaboonnnnn/toktickit/pull/16) → lab2-staging`r
+- Issue: [#15 — Lab 2: Sprint Engineering Contract and Test Plan](https://github.com/Tanaboonnnnn/toktickit/issues/15)
+- Pull request: [#16](https://github.com/Tanaboonnnnn/toktickit/pull/16) → `lab2-staging`
 - Peer-review evidence follow-up: [Issue #36 — Complete Peer Review Evidence](https://github.com/Tanaboonnnnn/toktickit/issues/36)
 
 ## Reviewers
 
-- Name: เธเธฅเธฑเธเธเน เธญเธกเธฒเธ•เธขเนเธเธขเธฒเธ เธฒ
+- Name: พลัฏฐ์ อมาตย์ชยาภา
 - Student ID: `67070507212`
 - GitHub username: `@L0u1sss`
 - Lab 2 review coverage verified on GitHub: PR #16, PR #21, PR #25, and PR #27.
 
-- Name: เธเธฒเธเธเธฑเธเธขเน เธญเธธเธ—เธฑเธขเธเธดเธเธนเธฅเธขเน
+- Name: ฌาธนัชย์ อุทัยพิบูลย์
 - Student ID: `67070507210`
 - GitHub username: `@Chxtamos`
 - Lab 2 review coverage verified on GitHub: PR #17, PR #19, PR #21, PR #23, PR #27, PR #29, PR #31, PR #32, PR #34, and PR #33.
@@ -45,13 +45,13 @@ The table below is an auditable index of the Lab 2 reviews received in this repo
 
 ## Detailed review evidence
 
-### Review 1 โ€” 2026-08-24 11:20 UTC
+### Review 1 — 2026-08-24 11:20 UTC
 
 - Result: **Changes requested**
 - Main contract findings: the Empty/No Results probe used invalid `pageSize=1`, and Category ordering conflicted with the existing Lab 1 `id asc` behavior.
 - Response: changed the unrestricted probe to `pageSize=10` and restored Category ordering to `id asc`. Findings about the separate incomplete implementation were not used to weaken the engineering contract.
 
-### Review 2 โ€” 2026-08-24 14:49 UTC
+### Review 2 — 2026-08-24 14:49 UTC
 
 - Result: **Changes requested**
 - Review: [PR #16](https://github.com/Tanaboonnnnn/toktickit/pull/16)
@@ -59,7 +59,7 @@ The table below is an auditable index of the Lab 2 reviews received in this repo
 - Response: the contract and planned-test wording were updated for those confirmed inconsistencies. Production-hardening scope was retained because it is a deliberate design choice rather than a confirmed defect.
 - Still open from this review: actual `ai-use.md` evidence, peer-review evidence completion, and the branch-number convention.
 
-### Review 3 โ€” 2026-08-24 15:47 UTC
+### Review 3 — 2026-08-24 15:47 UTC
 
 - Result: **Changes requested**
 - Review evidence: [GitHub review](https://github.com/Tanaboonnnnn/toktickit/pull/16#pullrequestreview-5009163494)
@@ -68,7 +68,7 @@ The table below is an auditable index of the Lab 2 reviews received in this repo
 - Response: this file now records the real review evidence, and UI-03 was added to the AC-37 traceability row in `tests.md`.
 - Branch status: `feature/5-lab2-engineering-contract` was not renamed. This remains a historical branch-number deviation, but PR #16 was subsequently approved and merged into `lab2-staging`.
 
-### Final PR #16 approval and merge โ€” 2026-08-24
+### Final PR #16 approval and merge — 2026-08-24
 
 - Final reviewer verdict: **Approved** by `@L0u1sss` at 2026-08-24 16:18 UTC.
 - Merge: PR #16 merged into `lab2-staging` at 2026-08-24 16:18 UTC as merge commit [`29f7697`](https://github.com/Tanaboonnnnn/toktickit/commit/29f7697e1c394eb9a391e45a64de95fab01dc303).
@@ -90,7 +90,7 @@ The table below is an auditable index of the Lab 2 reviews received in this repo
 
 ## Issue #28 / PR #29 review evidence
 
-### Review 4 โ€” 2026-08-29 19:33 UTC
+### Review 4 — 2026-08-29 19:33 UTC
 
 - Result: **Changes requested**
 - Reviewer: `@Chxtamos`

--- a/docs/lab-02/reviewer.md
+++ b/docs/lab-02/reviewer.md
@@ -4,53 +4,54 @@ This file records only peer-review evidence that actually occurred. Approval is 
 
 ## Author and review context
 
-- Author name: `แทนบุญ เตียวสวัสดิ์`
+- Author name: `เนเธ—เธเธเธธเธ เน€เธ•เธตเธขเธงเธชเธงเธฑเธชเธ”เธดเน`
 - Student ID: `67070507211`
 - GitHub username: `@Tanaboonnnnn`
 - Feature branch: `feature/5-lab2-engineering-contract`
-- Issue: [#15 — Lab 2: Sprint Engineering Contract and Test Plan](https://github.com/Tanaboonnnnn/toktickit/issues/15)
-- Pull request: [#16](https://github.com/Tanaboonnnnn/toktickit/pull/16) → `lab2-staging`
+- Issue: [#15 โ€” Lab 2: Sprint Engineering Contract and Test Plan](https://github.com/Tanaboonnnnn/toktickit/issues/15)
+- Pull request: [#16](https://github.com/Tanaboonnnnn/toktickit/pull/16) → lab2-staging`r
+- Peer-review evidence follow-up: [Issue #36 — Complete Peer Review Evidence](https://github.com/Tanaboonnnnn/toktickit/issues/36)
 
 ## Reviewers
 
-- Name: พลัฏฐ์ อมาตย์ชยาภา
+- Name: เธเธฅเธฑเธเธเน เธญเธกเธฒเธ•เธขเนเธเธขเธฒเธ เธฒ
 - Student ID: `67070507212`
 - GitHub username: `@L0u1sss`
 - Lab 2 review coverage verified on GitHub: PR #16, PR #21, PR #25, and PR #27.
 
-- Name: ฌาธนัชย์ อุทัยพิบูลย์
+- Name: เธเธฒเธเธเธฑเธเธขเน เธญเธธเธ—เธฑเธขเธเธดเธเธนเธฅเธขเน
 - Student ID: `67070507210`
 - GitHub username: `@Chxtamos`
 - Lab 2 review coverage verified on GitHub: PR #17, PR #19, PR #21, PR #23, PR #27, PR #29, PR #31, PR #32, PR #34, and PR #33.
 
 ## Reviews received
 
-The table below lists the Lab 2 PR reviews verified from the GitHub review history for this repository. Detailed notes are kept below for the review cycles that produced important changes to the work.
+The table below is an auditable index of the Lab 2 reviews received in this repository. Each outcome is linked to the actual GitHub review submission; dates are UTC. Where a PR had more than one review round, both the first blocking review and the final approval are linked. PR #21 is intentionally recorded without an approval because none was verified before merge.
 
-| PR | Scope | Reviewer(s) | Verified review outcome |
+| PR | Scope | Reviewer(s) | Review trail (UTC) |
 |---|---|---|---|
-| [#16](https://github.com/Tanaboonnnnn/toktickit/pull/16) | Engineering Contract / Test Plan | `@L0u1sss` | Changes requested, then approved and merged |
-| [#17](https://github.com/Tanaboonnnnn/toktickit/pull/17) | Development Requester | `@Chxtamos` | Changes requested, then approved |
-| [#19](https://github.com/Tanaboonnnnn/toktickit/pull/19) | Ticket Creation API | `@Chxtamos` | Changes requested, then approved |
-| [#21](https://github.com/Tanaboonnnnn/toktickit/pull/21) | Create Ticket UI | `@Chxtamos`, `@L0u1sss` | Changes requested were recorded; no final approval was verified before merge |
-| [#23](https://github.com/Tanaboonnnnn/toktickit/pull/23) | My Tickets | `@Chxtamos` | Approved |
-| [#25](https://github.com/Tanaboonnnnn/toktickit/pull/25) | Ticket Detail | `@L0u1sss` | Approved |
-| [#27](https://github.com/Tanaboonnnnn/toktickit/pull/27) | Attachment lifecycle | `@L0u1sss`, `@Chxtamos` | Changes requested during review; final approval recorded by `@Chxtamos` |
-| [#29](https://github.com/Tanaboonnnnn/toktickit/pull/29) | E2E / Responsive quality | `@Chxtamos` | Changes requested, then approved |
-| [#31](https://github.com/Tanaboonnnnn/toktickit/pull/31) | Release readiness | `@Chxtamos` | Approved |
-| [#32](https://github.com/Tanaboonnnnn/toktickit/pull/32) | Final evidence sync | `@Chxtamos` | Approved |
-| [#34](https://github.com/Tanaboonnnnn/toktickit/pull/34) | Release hygiene | `@Chxtamos` | Approved |
-| [#33](https://github.com/Tanaboonnnnn/toktickit/pull/33) | Final Lab 2 release | `@Chxtamos` | Changes requested, then approved and merged to `main` |
+| [#16](https://github.com/Tanaboonnnnn/toktickit/pull/16) | Engineering Contract / Test Plan | `@L0u1sss` | [Changes requested](https://github.com/Tanaboonnnnn/toktickit/pull/16#pullrequestreview-5007241677) 2026-08-24 → [Approved](https://github.com/Tanaboonnnnn/toktickit/pull/16#pullrequestreview-5010088830) 2026-08-24 |
+| [#17](https://github.com/Tanaboonnnnn/toktickit/pull/17) | Development Requester | `@Chxtamos` | [Changes requested](https://github.com/Tanaboonnnnn/toktickit/pull/17#pullrequestreview-5018840546) 2026-08-25 → [Approved](https://github.com/Tanaboonnnnn/toktickit/pull/17#pullrequestreview-5020303011) 2026-08-25 |
+| [#19](https://github.com/Tanaboonnnnn/toktickit/pull/19) | Ticket Creation API | `@Chxtamos` | [Changes requested](https://github.com/Tanaboonnnnn/toktickit/pull/19#pullrequestreview-5021406624) 2026-08-25 → [Approved](https://github.com/Tanaboonnnnn/toktickit/pull/19#pullrequestreview-5021962962) 2026-08-25 |
+| [#21](https://github.com/Tanaboonnnnn/toktickit/pull/21) | Create Ticket UI | `@Chxtamos`, `@L0u1sss` | `@Chxtamos` [changes requested](https://github.com/Tanaboonnnnn/toktickit/pull/21#pullrequestreview-5031094548) 2026-08-26; `@L0u1sss` [changes requested](https://github.com/Tanaboonnnnn/toktickit/pull/21#pullrequestreview-5031215706) 2026-08-26; no final approval verified before merge |
+| [#23](https://github.com/Tanaboonnnnn/toktickit/pull/23) | My Tickets | `@Chxtamos` | [Approved](https://github.com/Tanaboonnnnn/toktickit/pull/23#pullrequestreview-5044270164) 2026-08-27 |
+| [#25](https://github.com/Tanaboonnnnn/toktickit/pull/25) | Ticket Detail | `@L0u1sss` | [Approved](https://github.com/Tanaboonnnnn/toktickit/pull/25#pullrequestreview-5045385662) 2026-08-27 |
+| [#27](https://github.com/Tanaboonnnnn/toktickit/pull/27) | Attachment lifecycle | `@L0u1sss`, `@Chxtamos` | `@L0u1sss` [changes requested](https://github.com/Tanaboonnnnn/toktickit/pull/27#pullrequestreview-5055085130) 2026-08-28; `@Chxtamos` [changes requested](https://github.com/Tanaboonnnnn/toktickit/pull/27#pullrequestreview-5057999059) 2026-08-29 → [Approved](https://github.com/Tanaboonnnnn/toktickit/pull/27#pullrequestreview-5058314586) 2026-08-29 |
+| [#29](https://github.com/Tanaboonnnnn/toktickit/pull/29) | E2E / Responsive quality | `@Chxtamos` | [Changes requested](https://github.com/Tanaboonnnnn/toktickit/pull/29#pullrequestreview-5058988936) 2026-08-29 → [Approved](https://github.com/Tanaboonnnnn/toktickit/pull/29#pullrequestreview-5060290944) 2026-08-30 |
+| [#31](https://github.com/Tanaboonnnnn/toktickit/pull/31) | Release readiness | `@Chxtamos` | [Approved](https://github.com/Tanaboonnnnn/toktickit/pull/31#pullrequestreview-5061178775) 2026-08-30 |
+| [#32](https://github.com/Tanaboonnnnn/toktickit/pull/32) | Final evidence sync | `@Chxtamos` | [Approved](https://github.com/Tanaboonnnnn/toktickit/pull/32#pullrequestreview-5061448316) 2026-08-30 |
+| [#34](https://github.com/Tanaboonnnnn/toktickit/pull/34) | Release hygiene | `@Chxtamos` | [Approved](https://github.com/Tanaboonnnnn/toktickit/pull/34#pullrequestreview-5066675322) 2026-08-31 |
+| [#33](https://github.com/Tanaboonnnnn/toktickit/pull/33) | Final Lab 2 release | `@Chxtamos` | [Changes requested](https://github.com/Tanaboonnnnn/toktickit/pull/33#pullrequestreview-5066229800) 2026-08-31 → [Approved](https://github.com/Tanaboonnnnn/toktickit/pull/33#pullrequestreview-5066705949) 2026-08-31; merged to `main` |
 
 ## Detailed review evidence
 
-### Review 1 — 2026-08-24 11:20 UTC
+### Review 1 โ€” 2026-08-24 11:20 UTC
 
 - Result: **Changes requested**
 - Main contract findings: the Empty/No Results probe used invalid `pageSize=1`, and Category ordering conflicted with the existing Lab 1 `id asc` behavior.
 - Response: changed the unrestricted probe to `pageSize=10` and restored Category ordering to `id asc`. Findings about the separate incomplete implementation were not used to weaken the engineering contract.
 
-### Review 2 — 2026-08-24 14:49 UTC
+### Review 2 โ€” 2026-08-24 14:49 UTC
 
 - Result: **Changes requested**
 - Review: [PR #16](https://github.com/Tanaboonnnnn/toktickit/pull/16)
@@ -58,7 +59,7 @@ The table below lists the Lab 2 PR reviews verified from the GitHub review histo
 - Response: the contract and planned-test wording were updated for those confirmed inconsistencies. Production-hardening scope was retained because it is a deliberate design choice rather than a confirmed defect.
 - Still open from this review: actual `ai-use.md` evidence, peer-review evidence completion, and the branch-number convention.
 
-### Review 3 — 2026-08-24 15:47 UTC
+### Review 3 โ€” 2026-08-24 15:47 UTC
 
 - Result: **Changes requested**
 - Review evidence: [GitHub review](https://github.com/Tanaboonnnnn/toktickit/pull/16#pullrequestreview-5009163494)
@@ -67,7 +68,7 @@ The table below lists the Lab 2 PR reviews verified from the GitHub review histo
 - Response: this file now records the real review evidence, and UI-03 was added to the AC-37 traceability row in `tests.md`.
 - Branch status: `feature/5-lab2-engineering-contract` was not renamed. This remains a historical branch-number deviation, but PR #16 was subsequently approved and merged into `lab2-staging`.
 
-### Final PR #16 approval and merge — 2026-08-24
+### Final PR #16 approval and merge โ€” 2026-08-24
 
 - Final reviewer verdict: **Approved** by `@L0u1sss` at 2026-08-24 16:18 UTC.
 - Merge: PR #16 merged into `lab2-staging` at 2026-08-24 16:18 UTC as merge commit [`29f7697`](https://github.com/Tanaboonnnnn/toktickit/commit/29f7697e1c394eb9a391e45a64de95fab01dc303).
@@ -89,7 +90,7 @@ The table below lists the Lab 2 PR reviews verified from the GitHub review histo
 
 ## Issue #28 / PR #29 review evidence
 
-### Review 4 — 2026-08-29 19:33 UTC
+### Review 4 โ€” 2026-08-29 19:33 UTC
 
 - Result: **Changes requested**
 - Reviewer: `@Chxtamos`
@@ -143,20 +144,18 @@ Issue [#13](https://github.com/Tanaboonnnnn/toktickit/issues/13) was an early du
 
 ## Reviews given to peers
 
-GitHub Pull Requests search with `reviewed-by:Tanaboonnnnn` shows Lab 2 review activity in three classmates' TokTickIT repositories. Lab 1-only results are intentionally excluded from this section.
+The tables below list the Lab 2 PR reviews verified for `@Tanaboonnnnn` on GitHub. Every row links to the actual review submission and gives its UTC date and recorded verdict. For multi-round reviews, the table links the first blocking review and the final approval. Lab 1-only review activity is intentionally excluded.
 
 ### `@L0u1sss` — 6 Lab 2 PRs reviewed
 
-| PR | Scope | Review evidence |
+| PR | Scope | Review trail (UTC) |
 |---|---|---|
-| [#20](https://github.com/L0u1sss/TokTickIT/pull/20) | Specification, UI Tokens, and Test Plan Documentation | Review present on GitHub; latest search state showed Approved |
-| [#21](https://github.com/L0u1sss/TokTickIT/pull/21) | PostgreSQL Schema Design, Prisma Migrations, and Seed Data | Review present on GitHub; latest search state showed Approved |
-| [#22](https://github.com/L0u1sss/TokTickIT/pull/22) | Requester selection context | Review present on GitHub; latest search state showed Approved |
-| [#23](https://github.com/L0u1sss/TokTickIT/pull/23) | Create Ticket API, UI, and idempotency | Review present on GitHub; latest search state showed Approved |
-| [#24](https://github.com/L0u1sss/TokTickIT/pull/24) | Requester-scoped My Tickets list | [Changes Requested](https://github.com/L0u1sss/TokTickIT/pull/24#pullrequestreview-5058596777), partner [fix response](https://github.com/L0u1sss/TokTickIT/pull/24#issuecomment-5463665186), then [final Approval](https://github.com/L0u1sss/TokTickIT/pull/24#pullrequestreview-5058937767) |
-| [#27](https://github.com/L0u1sss/TokTickIT/pull/27) | Final E2E verification and release preparation | Review present on GitHub; latest search state showed Approved |
-
-The PR #24 review covered requester isolation, query-contract consistency, invalid URL-query handling, and reference-metadata failure states. The response added strict URL validation, an invalid-query state, metadata Loading/Error/Retry, safe error handling, tests, and synchronized docs before the re-review was approved.
+| [#20](https://github.com/L0u1sss/TokTickIT/pull/20) | Specification, UI Tokens, and Test Plan Documentation | [Changes requested](https://github.com/L0u1sss/TokTickIT/pull/20#pullrequestreview-5002758180) 2026-08-23 → [Approved](https://github.com/L0u1sss/TokTickIT/pull/20#pullrequestreview-5008898579) 2026-08-24 |
+| [#21](https://github.com/L0u1sss/TokTickIT/pull/21) | PostgreSQL Schema Design, Prisma Migrations, and Seed Data | [Changes requested](https://github.com/L0u1sss/TokTickIT/pull/21#pullrequestreview-5031688015) 2026-08-26 → [Approved](https://github.com/L0u1sss/TokTickIT/pull/21#pullrequestreview-5033474468) 2026-08-26 |
+| [#22](https://github.com/L0u1sss/TokTickIT/pull/22) | Requester selection context | [Approved](https://github.com/L0u1sss/TokTickIT/pull/22#pullrequestreview-5044909850) 2026-08-27 |
+| [#23](https://github.com/L0u1sss/TokTickIT/pull/23) | Create Ticket API, UI, and idempotency | [Approved](https://github.com/L0u1sss/TokTickIT/pull/23#pullrequestreview-5057782965) 2026-08-29 |
+| [#24](https://github.com/L0u1sss/TokTickIT/pull/24) | Requester-scoped My Tickets list | [Changes requested](https://github.com/L0u1sss/TokTickIT/pull/24#pullrequestreview-5058596777) 2026-08-29 → [partner response](https://github.com/L0u1sss/TokTickIT/pull/24#issuecomment-5463665186) → [Approved](https://github.com/L0u1sss/TokTickIT/pull/24#pullrequestreview-5058937767) 2026-08-29 |
+| [#27](https://github.com/L0u1sss/TokTickIT/pull/27) | Final E2E verification and release preparation | [Approved](https://github.com/L0u1sss/TokTickIT/pull/27#pullrequestreview-5069690813) 2026-08-31 |
 
 #### Selected detailed review — PR #24
 
@@ -168,21 +167,21 @@ The PR #24 review covered requester isolation, query-contract consistency, inval
 
 ### `@Peepipat-Suesoongnuen` — 13 Lab 2 PRs reviewed
 
-| PR | Scope | Latest review state shown by GitHub search |
+| PR | Scope | Review trail (UTC) |
 |---|---|---|
-| [#24](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/24) | My Tickets - owned paginated list, search/filter/sort/pagination | Changes requested |
-| [#25](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/25) | Ticket Detail + Attachment lifecycle | Approved |
-| [#26](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/26) | E2E tests + responsive Playwright screenshots | Approved |
-| [#28](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/28) | Add missing Create Ticket coverage | Approved |
-| [#29](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/29) | Complete Zen Green UI style and docs | Approved |
-| [#32](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/32) | Refine My Tickets search, sorting, and navigation | Approved |
-| [#33](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/33) | Add Back to My Tickets navigation | Approved |
-| [#35](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/35) | Refine My Tickets readability and filters | Approved |
-| [#36](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/36) | Complete release integration evidence | Approved |
-| [#37](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/37) | Lab 2 release | Changes requested, then approved on re-review |
-| [#39](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/39) | Keep tickets visible during sorting | Approved |
-| [#41](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/41) | Sync final evidence to staging | Approved |
-| [#42](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/42) | Promote final evidence to main | Approved |
+| [#24](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/24) | My Tickets — owned paginated list, search/filter/sort/pagination | [Changes requested](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/24#pullrequestreview-5061046815) 2026-08-30 → [Approved](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/24#pullrequestreview-5061250018) 2026-08-30 |
+| [#25](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/25) | Ticket Detail + Attachment lifecycle | [Changes requested](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/25#pullrequestreview-5066427225) 2026-08-31 → [Approved](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/25#pullrequestreview-5069658269) 2026-08-31 |
+| [#26](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/26) | E2E tests + responsive Playwright screenshots | [Approved](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/26#pullrequestreview-5075908254) 2026-09-01 |
+| [#28](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/28) | Add missing Create Ticket coverage | [Approved](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/28#pullrequestreview-5080177965) 2026-09-01 |
+| [#29](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/29) | Complete Zen Green UI style and docs | [Approved](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/29#pullrequestreview-5081784217) 2026-09-01 |
+| [#32](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/32) | Refine My Tickets search, sorting, and navigation | [Approved](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/32#pullrequestreview-5091663103) 2026-09-02 |
+| [#33](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/33) | Add Back to My Tickets navigation | [Approved](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/33#pullrequestreview-5092522831) 2026-09-02 |
+| [#35](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/35) | Refine My Tickets readability and filters | [Approved](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/35#pullrequestreview-5101445529) 2026-09-03 |
+| [#36](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/36) | Complete release integration evidence | [Changes requested](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/36#pullrequestreview-5103845464) 2026-09-03 → [Approved](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/36#pullrequestreview-5105113084) 2026-09-03 |
+| [#37](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/37) | Lab 2 release | [Changes requested](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/37#pullrequestreview-5112400805) 2026-09-04 → [Approved](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/37#pullrequestreview-5113426617) 2026-09-04 |
+| [#39](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/39) | Keep tickets visible during sorting | [Approved](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/39#pullrequestreview-5111734934) 2026-09-04 |
+| [#41](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/41) | Sync final evidence to staging | [Approved](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/41#pullrequestreview-5114881485) 2026-09-04 |
+| [#42](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/42) | Promote final evidence to main | [Changes requested](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/42#pullrequestreview-5115426597) 2026-09-04 → [Approved](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/42#pullrequestreview-5115715858) 2026-09-04 |
 
 #### Selected detailed review — PR #37
 
@@ -190,27 +189,27 @@ The PR #24 review covered requester isolation, query-contract consistency, inval
 - **What I found:** the release head itself was in good shape, but Issue #19 had already been closed as Completed even though its own acceptance criteria required it to stay open until the release PR was merged to `main`, the exact final-main CI was green, and the final evidence sync was complete.
 - **What I requested:** reopen Issue #19 and keep it open until the post-merge final-main gate was finished. I treated this as a process/evidence blocker, not a product-code blocker.
 - **Partner response:** the issue was reopened, `reviewer.md` was synchronized to record the release review, and the exact-head CI was rerun with client/server/E2E green. The follow-up was documentation/process-state only; no production or test behavior was changed for this fix.
-- **Re-review result:** after confirming the issue state and exact-head CI, I approved the release PR. I also noted that final-main verification and the final evidence sync still had to happen after merge before Issue #19 could be closed again.
+- **Re-review result:** [Changes Requested](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/37#pullrequestreview-5112400805) → after the process/evidence correction, I rechecked the issue state and exact-head CI and [Approved](https://github.com/Peepipat-Suesoongnuen/TokTickIT/pull/37#pullrequestreview-5113426617) on 2026-09-04. Final-main verification and the final evidence sync still remained post-merge work.
 
 ### `@Chxtamos` — 15 Lab 2 PRs reviewed
 
-| PR | Scope | Review evidence |
+| PR | Scope | Review trail (UTC) |
 |---|---|---|
-| [#13](https://github.com/Chxtamos/-TokTickIT-/pull/13) | Engineering contract and test plan | Review present on GitHub |
-| [#15](https://github.com/Chxtamos/-TokTickIT-/pull/15) | Lab 2 data model and seed | Review present on GitHub |
-| [#17](https://github.com/Chxtamos/-TokTickIT-/pull/17) | Requester context API | Review present on GitHub |
-| [#19](https://github.com/Chxtamos/-TokTickIT-/pull/19) | Ticket creation API | Review present on GitHub |
-| [#21](https://github.com/Chxtamos/-TokTickIT-/pull/21) | My Tickets API | Review present on GitHub |
-| [#25](https://github.com/Chxtamos/-TokTickIT-/pull/25) | Attachment Lifecycle API | Review present on GitHub |
-| [#27](https://github.com/Chxtamos/-TokTickIT-/pull/27) | Development Requester selection and application shell | Review present on GitHub |
-| [#29](https://github.com/Chxtamos/-TokTickIT-/pull/29) | Create Ticket UI | Review present on GitHub |
-| [#31](https://github.com/Chxtamos/-TokTickIT-/pull/31) | My Tickets screen | Review present on GitHub |
-| [#33](https://github.com/Chxtamos/-TokTickIT-/pull/33) | Requester Ticket Detail screen | Review present on GitHub |
-| [#35](https://github.com/Chxtamos/-TokTickIT-/pull/35) | Attachment lifecycle UI | Review present on GitHub |
-| [#37](https://github.com/Chxtamos/-TokTickIT-/pull/37) | Zen Green style and accessibility evidence | Review present on GitHub |
-| [#44](https://github.com/Chxtamos/-TokTickIT-/pull/44) | E2E requester and ticket creation flow | Changes requested, then approved on re-review |
-| [#45](https://github.com/Chxtamos/-TokTickIT-/pull/45) | E2E My Tickets ownership and Ticket Detail flow | Review present on GitHub; latest search state showed Approved |
-| [#46](https://github.com/Chxtamos/-TokTickIT-/pull/46) | E2E Attachment lifecycle flow | Review present on GitHub; latest search state showed Changes requested |
+| [#13](https://github.com/Chxtamos/-TokTickIT-/pull/13) | Engineering contract and test plan | [Changes requested](https://github.com/Chxtamos/-TokTickIT-/pull/13#pullrequestreview-5007492513) 2026-08-24 → [Approved](https://github.com/Chxtamos/-TokTickIT-/pull/13#pullrequestreview-5009068037) 2026-08-24 |
+| [#15](https://github.com/Chxtamos/-TokTickIT-/pull/15) | Lab 2 data model and seed | [Changes requested](https://github.com/Chxtamos/-TokTickIT-/pull/15#pullrequestreview-5020387687) 2026-08-25 → [Approved](https://github.com/Chxtamos/-TokTickIT-/pull/15#pullrequestreview-5021493072) 2026-08-25 |
+| [#17](https://github.com/Chxtamos/-TokTickIT-/pull/17) | Requester context API | [Changes requested](https://github.com/Chxtamos/-TokTickIT-/pull/17#pullrequestreview-5031668182) 2026-08-26 → [Approved](https://github.com/Chxtamos/-TokTickIT-/pull/17#pullrequestreview-5057924294) 2026-08-29 |
+| [#19](https://github.com/Chxtamos/-TokTickIT-/pull/19) | Ticket creation API | [Changes requested](https://github.com/Chxtamos/-TokTickIT-/pull/19#pullrequestreview-5058327229) 2026-08-29; no later approval by `@Tanaboonnnnn` was verified |
+| [#21](https://github.com/Chxtamos/-TokTickIT-/pull/21) | My Tickets API | [Approved](https://github.com/Chxtamos/-TokTickIT-/pull/21#pullrequestreview-5060381829) 2026-08-30 |
+| [#25](https://github.com/Chxtamos/-TokTickIT-/pull/25) | Attachment Lifecycle API | [Changes requested](https://github.com/Chxtamos/-TokTickIT-/pull/25#pullrequestreview-5061127238) 2026-08-30 → [Approved](https://github.com/Chxtamos/-TokTickIT-/pull/25#pullrequestreview-5061161506) 2026-08-30 |
+| [#27](https://github.com/Chxtamos/-TokTickIT-/pull/27) | Development Requester selection and application shell | [Changes requested](https://github.com/Chxtamos/-TokTickIT-/pull/27#pullrequestreview-5061315313) 2026-08-30 → [Approved](https://github.com/Chxtamos/-TokTickIT-/pull/27#pullrequestreview-5066673046) 2026-08-31 |
+| [#29](https://github.com/Chxtamos/-TokTickIT-/pull/29) | Create Ticket UI | [Changes requested](https://github.com/Chxtamos/-TokTickIT-/pull/29#pullrequestreview-5067780252) 2026-08-31 → [Approved](https://github.com/Chxtamos/-TokTickIT-/pull/29#pullrequestreview-5075095202) 2026-09-01 |
+| [#31](https://github.com/Chxtamos/-TokTickIT-/pull/31) | My Tickets screen | [Changes requested](https://github.com/Chxtamos/-TokTickIT-/pull/31#pullrequestreview-5079605515) 2026-09-01 → [Approved](https://github.com/Chxtamos/-TokTickIT-/pull/31#pullrequestreview-5080314714) 2026-09-01 |
+| [#33](https://github.com/Chxtamos/-TokTickIT-/pull/33) | Requester Ticket Detail screen | [Changes requested](https://github.com/Chxtamos/-TokTickIT-/pull/33#pullrequestreview-5086456485) 2026-09-02 → [Approved](https://github.com/Chxtamos/-TokTickIT-/pull/33#pullrequestreview-5086585835) 2026-09-02 |
+| [#35](https://github.com/Chxtamos/-TokTickIT-/pull/35) | Attachment lifecycle UI | [Changes requested](https://github.com/Chxtamos/-TokTickIT-/pull/35#pullrequestreview-5086993754) 2026-09-02 → [Approved](https://github.com/Chxtamos/-TokTickIT-/pull/35#pullrequestreview-5087273555) 2026-09-02 |
+| [#37](https://github.com/Chxtamos/-TokTickIT-/pull/37) | Zen Green style and accessibility evidence | [Changes requested](https://github.com/Chxtamos/-TokTickIT-/pull/37#pullrequestreview-5088965367) 2026-09-02 → [Approved](https://github.com/Chxtamos/-TokTickIT-/pull/37#pullrequestreview-5090861536) 2026-09-02 |
+| [#44](https://github.com/Chxtamos/-TokTickIT-/pull/44) | E2E requester and ticket creation flow | [Changes requested](https://github.com/Chxtamos/-TokTickIT-/pull/44#pullrequestreview-5102512321) 2026-09-03 → [Approved](https://github.com/Chxtamos/-TokTickIT-/pull/44#pullrequestreview-5102678319) 2026-09-03 |
+| [#45](https://github.com/Chxtamos/-TokTickIT-/pull/45) | E2E My Tickets ownership and Ticket Detail flow | [Approved](https://github.com/Chxtamos/-TokTickIT-/pull/45#pullrequestreview-5103406106) 2026-09-03 |
+| [#46](https://github.com/Chxtamos/-TokTickIT-/pull/46) | E2E Attachment lifecycle flow | [Changes requested](https://github.com/Chxtamos/-TokTickIT-/pull/46#pullrequestreview-5104513654) 2026-09-03 → [Approved](https://github.com/Chxtamos/-TokTickIT-/pull/46#pullrequestreview-5116518154) 2026-09-04 |
 
 #### Selected detailed review — PR #44
 
@@ -218,8 +217,7 @@ The PR #24 review covered requester isolation, query-contract consistency, inval
 - **What I found:** the E2E-01 flow itself was strong, including requester selection, ambiguous create-response handling, retry of the same logical request, mixed PDF/PNG attachment behavior, partial attachment failure with individual retry, and authoritative metadata checks. The blocker was traceability: the PR was being treated like the complete final-verification Issue even though `tests.md` still had E2E-02 through E2E-06 as Planned, and the workflow had only one seed run even though the final-verification criteria called for a seed-twice idempotency check.
 - **What I requested:** either complete the full final-verification evidence or narrow the PR back to the E2E-01 feature scope. I also asked for the seed-twice verification required by the final gate and for the evidence to stop overclaiming unimplemented E2E IDs.
 - **Partner response:** the PR scope was corrected to Feature 18 / Issue #38 / E2E-01 only, the separate final-verification Issue was left as a follow-up, the workflow ran `prisma:seed` twice, and `tests.md` marked only E2E-01 as PASS while E2E-02 through E2E-06 stayed Planned.
-- **Re-review result:** I rechecked the updated scope and exact-head CI. Client, server, and hosted E2E were green, the traceability mismatch was gone, and I approved the PR.
-
+- **Re-review result:** [Changes Requested](https://github.com/Chxtamos/-TokTickIT-/pull/44#pullrequestreview-5102512321) → after the scope/seed/traceability corrections, I rechecked the exact-head CI and [Approved](https://github.com/Chxtamos/-TokTickIT-/pull/44#pullrequestreview-5102678319) on 2026-09-03.
 ## Evidence integrity note
 
 This file records review evidence verified from the live GitHub Pull Requests pages and PR timelines for the Lab 2 work above. The received-review index covers the Lab 2 PRs reviewed by `@L0u1sss` and `@Chxtamos`; the reviews-given section covers the Lab 2 PRs found for `@L0u1sss`, `@Peepipat-Suesoongnuen`, and `@Chxtamos` under `reviewed-by:Tanaboonnnnn`. Lab 1-only review results are excluded from the Lab 2 tables. The file does not claim a hosted passing-check link where none was verified. Test/build/Prisma/browser results in `tests.md` are local execution evidence, not substitutes for peer approval.


### PR DESCRIPTION
## Summary

Promote the reviewed Lab 2 peer-review evidence from `lab2-staging` to `main` after PR #35 was approved and merged.

This follow-up keeps `main` as the final source of truth for the Lab 2 submission. The release diff contains only `docs/lab-02/reviewer.md`; there are no application, API, database, migration, dependency, or test-behavior changes.

## Review history

- PR #35 (`feature/16-lab2-peer-review-evidence` -> `lab2-staging`) received Changes Requested from `@Chxtamos`.
- Issue #36 was added for traceability and PR #35 references it.
- Review evidence was made auditable with direct GitHub review links, UTC dates, verdicts, partner responses, and re-review outcomes where available.
- `@Chxtamos` re-reviewed and approved PR #35.
- PR #35 was then merged into `lab2-staging`.

## Changes promoted to main

- Identify both peers who reviewed my Lab 2 work.
- Record the verified reviews received across Lab 2.
- Record 34 Lab 2 PR reviews I gave to classmates.
- Add direct review links, dates, and verdicts instead of relying on summary-only claims.
- Preserve selected detailed review examples showing what I checked, what I found, what I requested, the partner response, and the re-review result.
- Preserve the final PR #33 / PR #34 release-review evidence.

## Verification on current `lab2-staging` head

Verified before opening this PR at `e741524`:

- Server tests: **30/30 files, 142/142 tests passed**
- Server build: **Passed**
- Prisma validate / generate / migrate status: **Passed**
- Client tests: **17/17 files, 120/120 tests passed**
- Client build: **Passed**
- E2E Chromium: **23/23 passed**
- Responsive Chromium: **10/10 passed**
- `git diff --check origin/main..origin/lab2-staging`: **Passed**
- Working tree was restored clean after Playwright regenerated screenshot artifacts.

## Release diff

`main..lab2-staging` changes exactly one file:

- `docs/lab-02/reviewer.md`

## Traceability

Refs #36

Please review this promotion PR before merging to `main`.